### PR TITLE
Membership CTAs to Google Form + event banner/badge fixes

### DIFF
--- a/rc-website/src/components/EventNotification.tsx
+++ b/rc-website/src/components/EventNotification.tsx
@@ -86,9 +86,13 @@ const EventBadge: React.FC<EventNotificationProps> = ({ event, onDismiss }) => {
 
   if (!timeUntil) return null;
 
+  const href = event.registrationUrl || "/meetup";
+  const isExternal = /^https?:\/\//.test(href);
+
   return (
     <Link
-      href="/meetup"
+      href={href}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
       className="relative group event-notification-focusable"
       aria-label={`Upcoming event: ${event.title} in ${timeUntil.days} days`}
     >
@@ -135,6 +139,9 @@ const EventBanner: React.FC<EventNotificationProps> = ({
     setIsVisible(false);
     onDismiss?.();
   };
+
+  const registrationHref = event.registrationUrl || "/meetup";
+  const isExternal = /^https?:\/\//.test(registrationHref);
 
   return (
     <div
@@ -188,8 +195,9 @@ const EventBanner: React.FC<EventNotificationProps> = ({
               </div>
             </div>
             
-            <Link 
-              href="/meetup"
+            <Link
+              href={registrationHref}
+              {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
               className="text-xs bg-yellow-secondary text-black px-2 py-1 rounded-full font-semibold hover:bg-yellow-secondary/90 transition-colors flex-shrink-0"
               aria-label={`Register for ${event.title}`}
             >
@@ -244,8 +252,9 @@ const EventBanner: React.FC<EventNotificationProps> = ({
           </div>
 
           <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
-            <Link 
-              href="/meetup"
+            <Link
+              href={registrationHref}
+              {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
               className="text-sm bg-yellow-secondary text-black px-3 py-1.5 rounded-full font-semibold hover:bg-yellow-secondary/90 transition-colors shadow-md hover:shadow-lg"
               aria-label={`Register for ${event.title}`}
             >
@@ -284,9 +293,13 @@ const EventCountdown: React.FC<EventNotificationProps> = ({ event }) => {
 
   if (!timeUntil) return null;
 
+  const href = event.registrationUrl || "/meetup";
+  const isExternal = /^https?:\/\//.test(href);
+
   return (
     <Link
-      href="/meetup"
+      href={href}
+      {...(isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
       className="block event-notification-focusable"
       aria-label={`Next meetup countdown: ${timeUntil.days} days, ${timeUntil.hours} hours, ${timeUntil.minutes} minutes remaining`}
     >

--- a/rc-website/src/components/HeroSection.tsx
+++ b/rc-website/src/components/HeroSection.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import { ChevronRight } from "lucide-react";
-import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
 import { getCldVideoUrl } from "next-cloudinary";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -138,15 +137,19 @@ export const HeroSection = () => {
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/contact">
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLSd366e4bzN3yZAiWgNSJgT9FlJfaVEv0H0nMyTe3JKrQVj00Q/viewform"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <Button
                 variant="default"
                 className="px-8 py-6 text-lg rounded-3xl"
                 size="lg"
               >
-                Join Us
+                Apply Now
               </Button>
-            </Link>
+            </a>
           </div>
         </div>
       </div>

--- a/rc-website/src/components/Navbar.tsx
+++ b/rc-website/src/components/Navbar.tsx
@@ -127,7 +127,7 @@ export function Navbar({ nextEvent, settings }: NavbarProps) {
             >
               Projects
             </Link>
-            <div className="flex items-center gap-2 relative group">
+            <div className="flex items-center gap-2 relative group/events">
               {/* Main Events Link */}
               <div className="relative">
                 <button
@@ -138,13 +138,13 @@ export function Navbar({ nextEvent, settings }: NavbarProps) {
                   }`}
                 >
                   Events
-                  <svg className="w-4 h-4 transition-transform duration-200 group-hover:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4 transition-transform duration-200 group-hover/events:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
                 </button>
-                
+
                 {/* Dropdown Menu */}
-                <div className="absolute top-full left-0 mt-2 w-36 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 ease-out transform translate-y-2 group-hover:translate-y-0 z-50">
+                <div className="absolute top-full left-0 mt-2 w-36 opacity-0 invisible group-hover/events:opacity-100 group-hover/events:visible transition-all duration-300 ease-out transform translate-y-2 group-hover/events:translate-y-0 z-50">
                   <div className="bg-card/95 backdrop-blur-md border border-primary/20 rounded-lg shadow-lg overflow-hidden">
                     {/* Meetup Option */}
                     <a
@@ -177,7 +177,7 @@ export function Navbar({ nextEvent, settings }: NavbarProps) {
                 </div>
               </div>
               
-              {settings?.eventControls?.showEventNotificationBadge && nextEvent && (
+              {settings?.eventControls?.showEventNotificationBadge && nextEvent && !shouldShowBanner && (
                 <EventNotification
                   event={nextEvent}
                   variant="badge"
@@ -198,9 +198,13 @@ export function Navbar({ nextEvent, settings }: NavbarProps) {
           </div>
 
           <div className="hidden md:block">
-            <Link href="/positions">
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLSd366e4bzN3yZAiWgNSJgT9FlJfaVEv0H0nMyTe3JKrQVj00Q/viewform"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               <Button variant="default">Join Us</Button>
-            </Link>
+            </a>
           </div>
 
           <div className="md:hidden">
@@ -285,7 +289,7 @@ export function Navbar({ nextEvent, settings }: NavbarProps) {
                   Conference
                 </Link>
               </div>
-              {settings?.eventControls?.showEventNotificationBadge && nextEvent && (
+              {settings?.eventControls?.showEventNotificationBadge && nextEvent && !shouldShowBanner && (
                 <div className="mt-2 pl-4">
                   <EventNotification
                     event={nextEvent}
@@ -306,9 +310,14 @@ export function Navbar({ nextEvent, settings }: NavbarProps) {
             >
               Contact
             </Link>
-            <Link href="/positions" onClick={() => setMobileMenuOpen(false)}>
+            <a
+              href="https://docs.google.com/forms/d/e/1FAIpQLSd366e4bzN3yZAiWgNSJgT9FlJfaVEv0H0nMyTe3JKrQVj00Q/viewform"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setMobileMenuOpen(false)}
+            >
               <Button variant="default">Join Us</Button>
-            </Link>
+            </a>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Hero CTA relabeled to **Apply Now** and linked directly to the membership Google Form (new tab)
- Navbar Join Us (desktop + mobile) now opens the Google Form in a new tab — label kept as Join Us
- Event banner Register buttons and the badge/countdown click target now use `event.registrationUrl` with `/meetup` as fallback; external URLs open in a new tab
- Event badge is hidden while the banner is visible (removes duplicate info); reappears after banner dismissal or when the banner is disabled in Sanity
- Scoped the Events dropdown hover to a named Tailwind group (`group/events`) so hovering the Events button no longer incidentally triggers the adjacent event-badge tooltip

## Test plan
- [ ] Home: Hero Apply Now opens the Google Form in a new tab
- [ ] Navbar Join Us (desktop and mobile) opens the Google Form in a new tab
- [ ] With the event banner visible, the Events nav has no days-countdown badge
- [ ] Dismiss the banner → the days-countdown badge appears next to Events
- [ ] Hover Events → only the dropdown opens (no tooltip overlap from the badge)
- [ ] Hover the badge itself → tooltip shows event summary; click goes to the event's `registrationUrl` (or `/meetup` if unset)
- [ ] Banner Register Now/Register buttons go to `event.registrationUrl` when set