### PR TITLE
chore: remove em-dashes from user-facing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Robotics Collective Aachen — Website
+# Robotics Collective Aachen
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/e307b1b0-0632-4eea-9f87-295defcc6ffd/deploy-status)](https://app.netlify.com/projects/roboticscollective/deploys)
 
 One-page marketing site for **Robotics Collective Aachen**, a non-profit student robotics organization in Aachen, Germany and founding member of **ESRA** (European Student Robotics Association).
 
-Built with Next.js 15. All content is static — no CMS, no external data sources.
+Built with Next.js 15. All content is static. No external data sources. 
 
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) v18 or later
-- [Yarn](https://classic.yarnpkg.com/) (Classic, v1.x — see `packageManager` in `package.json`)
+- [Yarn](https://classic.yarnpkg.com/) (Classic, v1.x - see `packageManager` in `package.json`)
 
 ## Getting Started
 
@@ -24,10 +24,10 @@ The dev server runs at `http://localhost:3000`.
 
 ### Available Commands
 
-- **`yarn dev`** — Start the development server
-- **`yarn build`** — Create an optimized production build
-- **`yarn start`** — Start the production server (requires `yarn build` first)
-- **`yarn lint`** — Run ESLint
+- **`yarn dev`**: Start the development server
+- **`yarn build`**: Create an optimized production build
+- **`yarn start`**: Start the production server (requires `yarn build` first)
+- **`yarn lint`**: Run ESLint
 
 ## Tech Stack
 
@@ -40,12 +40,12 @@ The dev server runs at `http://localhost:3000`.
 
 ## Editing Content
 
-All copy and data lives in TypeScript files inside `rc-website/src/` — no admin panel needed.
+All copy and data lives in TypeScript files inside `rc-website/src/`. No admin panel needed.
 
-- Team / partners — `src/lib/team.ts`
-- FAQ — `src/components/FAQSection.tsx`
-- Hero / About / Vision copy — inline at the top of each section component in `src/components/`
-- Images — `rc-website/public/` (`team/`, `projects/`, `partners/`, etc.)
+- Team / partners: `src/lib/team.ts`
+- FAQ: `src/components/FAQSection.tsx`
+- Hero / About / Vision copy: inline at the top of each section component in `src/components/`
+- Images: `rc-website/public/` (`team/`, `projects/`, `partners/`, etc.)
 
 See **`PROJECT.md`** for the full landing-page structure and **`STYLE.md`** for the design-token reference.
 

--- a/rc-website/src/app/not-found.tsx
+++ b/rc-website/src/app/not-found.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Page Not Found — Robotics Collective Aachen",
+  title: "Page Not Found | Robotics Collective Aachen",
   description: "The page you're looking for couldn't be found",
 };
 

--- a/rc-website/src/components/AboutSection.tsx
+++ b/rc-website/src/components/AboutSection.tsx
@@ -28,7 +28,7 @@ export const AboutSection = () => {
             fontWeight: 500,
           }}
         >
-          01 — About the Collective
+          01 · About the Collective
         </p>
         <h2
           className="mb-[6vh] max-w-[100vh]"
@@ -75,7 +75,7 @@ export const AboutSection = () => {
             <p style={{ fontSize: "2.4vh", lineHeight: 1.5 }}>
               Founded in 2023 as <strong>open robotic metaverse</strong>, we
               quickly spotted a critical gap: Aachen's vibrant robotics
-              community was booming, yet efforts remained scattered — research
+              community was booming, yet efforts remained scattered: research
               institutes, startups, companies, and student teams often tackling
               the same challenges in parallel, reinventing the wheel.
             </p>

--- a/rc-website/src/components/FAQSection.tsx
+++ b/rc-website/src/components/FAQSection.tsx
@@ -31,13 +31,13 @@ const defaultItems: FAQItem[] = [
     id: "need-experience",
     question: "Do I need technical experience to join?",
     answer:
-      "Not at all. We welcome everyone from curious beginners to experienced roboticists. Beyond the technical side, skills in organization, marketing, and partnership management are essential to keeping things running and growing — so if that's your strength, we'd love to have you on board.",
+      "Not at all. We welcome everyone from curious beginners to experienced roboticists. Beyond the technical side, skills in organization, marketing, and partnership management are essential to keeping things running and growing, so if that's your strength, we'd love to have you on board.",
   },
   {
     id: "project-types",
     question: "What types of projects do you incubate?",
     answer:
-      "We work on all kinds of projects that push embodied AI forward — mobile robots, machine learning for perception, mechanical design, and human-robot interaction. From building something new to improving existing systems. We also encourage everyone to explore their own ideas, with the support and inspiration of the community.",
+      "We work on all kinds of projects that push embodied AI forward: mobile robots, machine learning for perception, mechanical design, and human-robot interaction. From building something new to improving existing systems. We also encourage everyone to explore their own ideas, with the support and inspiration of the community.",
   },
   {
     id: "events",
@@ -83,7 +83,7 @@ export const FAQSection = ({ items = defaultItems }: { items?: FAQItem[] }) => {
             fontWeight: 500,
           }}
         >
-          04 — FAQ
+          04 · FAQ
         </p>
         <h2
           className="mb-[6vh]"

--- a/rc-website/src/components/ProjectsSection.tsx
+++ b/rc-website/src/components/ProjectsSection.tsx
@@ -35,7 +35,7 @@ export const ProjectsSection = () => {
             fontWeight: 500,
           }}
         >
-          03 — Behind the Build
+          03 · Behind the Build
         </p>
         <h2
           className="mb-[6vh] max-w-[100vh]"

--- a/rc-website/src/components/TeamSection.tsx
+++ b/rc-website/src/components/TeamSection.tsx
@@ -41,7 +41,7 @@ export const TeamSection = () => {
             fontWeight: 500,
           }}
         >
-          05 — Team
+          05 · Team
         </p>
         <h2
           className="mb-[3vh] max-w-[110vh]"

--- a/rc-website/src/components/VisionSection.tsx
+++ b/rc-website/src/components/VisionSection.tsx
@@ -108,7 +108,7 @@ export const VisionSection = () => {
             fontWeight: 500,
           }}
         >
-          02 — European Network
+          02 · European Network
         </p>
 
         <h2
@@ -122,7 +122,7 @@ export const VisionSection = () => {
           style={{ fontSize: "2.5vh", color: "#ffffff99", lineHeight: 1.5 }}
         >
           Robotics Collective Aachen is a founding member of{" "}
-          <strong className="text-brand">ESRA</strong> — the European Student
+          <strong className="text-brand">ESRA</strong>, the European Student
           Robotics Association. Europe doesn&apos;t have a talent problem; it has a
           fragmentation problem. Together with 10+ student robotics
           organizations across the continent, we&apos;re building a unified network


### PR DESCRIPTION
- Rewrite prose em-dashes in About / FAQ / Vision with natural punctuation (commas, colons, periods)
- Switch "NN — Label" section headers to a middot separator
- 404 page title em-dash -> pipe
- README: em-dashes -> colons/periods, matching its existing style