### PR TITLE
fix: use stable svh units to stop viewport hop in mobile in-app browsers

### DIFF
--- a/rc-website/src/app/globals.css
+++ b/rc-website/src/app/globals.css
@@ -35,7 +35,7 @@
 
   body {
     @apply bg-dark text-dark font-satoshi;
-    font-size: 2vh;
+    font-size: 2svh;
     line-height: 1.4;
   }
 
@@ -56,44 +56,44 @@
   }
 
   /* ETH typography scale — viewport-relative */
-  .text-hero        { font-size: 9vh;  font-weight: 500; line-height: 1.3; }
-  .text-giant       { font-size: 40vh; font-weight: 500; line-height: 1;   color: var(--white-60); }
-  .text-section-num { font-size: 17vh; font-weight: 400; line-height: 1; }
-  .text-h1          { font-size: 10vh; font-weight: 400; line-height: 0.9; }
-  .text-h2          { font-size: 8vh;  font-weight: 500; line-height: 1.2; }
-  .text-h3          { font-size: 7vh;  font-weight: 500; line-height: 1.2; }
-  .text-h4          { font-size: 6vh;  font-weight: 400; line-height: 1.2; }
-  .text-h5          { font-size: 5vh;  font-weight: 500; line-height: 1.2; }
-  .text-card-title  { font-size: 3vh;  font-weight: 500; line-height: 1.4; }
-  .text-subheading  { font-size: 2.7vh; font-weight: 500; line-height: 1.2; }
-  .text-hero-sub    { font-size: 2.5vh; font-weight: 400; line-height: 1.4; }
-  .text-body        { font-size: 2vh;  font-weight: 400; line-height: 1.4; }
-  .text-nav         { font-size: 2vh;  font-weight: 500; line-height: 1.2; }
-  .text-small       { font-size: 1.8vh; font-weight: 500; line-height: 1.4; }
-  .text-btn         { font-size: 1.6vh; font-weight: 700; letter-spacing: 0.5vh; }
+  .text-hero        { font-size: 9svh;  font-weight: 500; line-height: 1.3; }
+  .text-giant       { font-size: 40svh; font-weight: 500; line-height: 1;   color: var(--white-60); }
+  .text-section-num { font-size: 17svh; font-weight: 400; line-height: 1; }
+  .text-h1          { font-size: 10svh; font-weight: 400; line-height: 0.9; }
+  .text-h2          { font-size: 8svh;  font-weight: 500; line-height: 1.2; }
+  .text-h3          { font-size: 7svh;  font-weight: 500; line-height: 1.2; }
+  .text-h4          { font-size: 6svh;  font-weight: 400; line-height: 1.2; }
+  .text-h5          { font-size: 5svh;  font-weight: 500; line-height: 1.2; }
+  .text-card-title  { font-size: 3svh;  font-weight: 500; line-height: 1.4; }
+  .text-subheading  { font-size: 2.7svh; font-weight: 500; line-height: 1.2; }
+  .text-hero-sub    { font-size: 2.5svh; font-weight: 400; line-height: 1.4; }
+  .text-body        { font-size: 2svh;  font-weight: 400; line-height: 1.4; }
+  .text-nav         { font-size: 2svh;  font-weight: 500; line-height: 1.2; }
+  .text-small       { font-size: 1.8svh; font-weight: 500; line-height: 1.4; }
+  .text-btn         { font-size: 1.6svh; font-weight: 700; letter-spacing: 0.5svh; }
 }
 
 @layer components {
   .section {
     @apply flex flex-col justify-center items-center;
-    min-height: 100vh;
-    padding: 5vh;
+    min-height: 100svh;
+    padding: 5svh;
   }
 
   .section-inner {
     width: 100%;
-    max-width: 150vh;
+    max-width: 150svh;
   }
 
   .btn-ghost {
     color: #fff;
     background-color: rgba(255, 255, 255, 0.1);
     border: none;
-    border-radius: 1vh;
-    padding: 2vh 5vh;
-    font-size: 1.6vh;
+    border-radius: 1svh;
+    padding: 2svh 5svh;
+    font-size: 1.6svh;
     font-weight: 700;
-    letter-spacing: 0.5vh;
+    letter-spacing: 0.5svh;
     cursor: pointer;
     transition: all 0.2s;
     text-transform: uppercase;
@@ -106,11 +106,11 @@
   .btn-solid-dark {
     color: #fff;
     background-color: #0d0d0d;
-    border-radius: 1vh;
-    padding: 2vh 5vh;
-    font-size: 1.6vh;
+    border-radius: 1svh;
+    padding: 2svh 5svh;
+    font-size: 1.6svh;
     font-weight: 700;
-    letter-spacing: 0.5vh;
+    letter-spacing: 0.5svh;
     cursor: pointer;
     transition: all 0.2s;
     text-transform: uppercase;
@@ -138,9 +138,9 @@
     color: #fff;
     background-color: transparent;
     border: 2px solid #fff;
-    border-radius: 2.5vh;
-    padding: 0.6vh 2vh;
-    font-size: 2vh;
+    border-radius: 2.5svh;
+    padding: 0.6svh 2svh;
+    font-size: 2svh;
     font-weight: 500;
     cursor: pointer;
     transition: all 0.2s;
@@ -158,9 +158,9 @@
     color: #0d0d0d;
     background-color: transparent;
     border: 2px solid #0d0d0d;
-    border-radius: 2.5vh;
-    padding: 0.6vh 2vh;
-    font-size: 2vh;
+    border-radius: 2.5svh;
+    padding: 0.6svh 2svh;
+    font-size: 2svh;
     font-weight: 500;
     cursor: pointer;
     transition: all 0.2s;

--- a/rc-website/src/app/imprint/page.tsx
+++ b/rc-website/src/app/imprint/page.tsx
@@ -7,9 +7,9 @@ export const metadata: Metadata = {
 
 export default function ImprintPage() {
   return (
-    <div className="min-h-screen bg-light text-dark" style={{ paddingTop: "12vh" }}>
-      <div style={{ padding: "5vh" }}>
-        <div className="max-w-[120vh] mx-auto">
+    <div className="min-h-svh bg-light text-dark" style={{ paddingTop: "12svh" }}>
+      <div style={{ padding: "5svh" }}>
+        <div className="max-w-[120svh] mx-auto">
           <h1 className="text-h2 mb-12">Imprint / Legal Notice</h1>
 
           <section>

--- a/rc-website/src/app/not-found.tsx
+++ b/rc-website/src/app/not-found.tsx
@@ -8,8 +8,8 @@ export const metadata: Metadata = {
 
 export default function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[80vh] text-center px-4">
-      <h1 style={{ fontSize: "20vh", fontWeight: 500, lineHeight: 1 }}>404</h1>
+    <div className="flex flex-col items-center justify-center min-h-[80svh] text-center px-4">
+      <h1 style={{ fontSize: "20svh", fontWeight: 500, lineHeight: 1 }}>404</h1>
       <p className="text-h5 mb-8">This page doesn't exist.</p>
       <Link href="/" className="btn-outline-pill-dark">
         Return Home

--- a/rc-website/src/app/privacy/page.tsx
+++ b/rc-website/src/app/privacy/page.tsx
@@ -8,9 +8,9 @@ export const metadata: Metadata = {
 
 export default function PrivacyPage() {
   return (
-    <div className="min-h-screen bg-light text-dark" style={{ paddingTop: "12vh" }}>
-      <div style={{ padding: "5vh" }}>
-        <div className="max-w-[120vh] mx-auto">
+    <div className="min-h-svh bg-light text-dark" style={{ paddingTop: "12svh" }}>
+      <div style={{ padding: "5svh" }}>
+        <div className="max-w-[120svh] mx-auto">
           <h1 className="text-h2 mb-12">Privacy Policy</h1>
 
           <section className="mb-16">

--- a/rc-website/src/components/AboutSection.tsx
+++ b/rc-website/src/components/AboutSection.tsx
@@ -3,13 +3,13 @@ export const AboutSection = () => {
     <section
       id="about"
       className="relative bg-light text-dark"
-      style={{ padding: "14vh 5vh", minHeight: "100vh" }}
+      style={{ padding: "14svh 5svh", minHeight: "100svh" }}
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none select-none absolute top-0 right-[5vh]"
+        className="pointer-events-none select-none absolute top-0 right-[5svh]"
         style={{
-          fontSize: "40vh",
+          fontSize: "40svh",
           fontWeight: 500,
           lineHeight: 1,
           color: "#d8d8d8",
@@ -18,32 +18,32 @@ export const AboutSection = () => {
         01
       </div>
 
-      <div className="relative max-w-[150vh] mx-auto">
+      <div className="relative max-w-[150svh] mx-auto">
         <p
           className="uppercase mb-4"
           style={{
-            letterSpacing: "0.3vh",
+            letterSpacing: "0.3svh",
             color: "#666",
-            fontSize: "1.8vh",
+            fontSize: "1.8svh",
             fontWeight: 500,
           }}
         >
           01 · About the Collective
         </p>
         <h2
-          className="mb-[6vh] max-w-[100vh]"
-          style={{ fontSize: "8vh", fontWeight: 700, lineHeight: 1.05 }}
+          className="mb-[6svh] max-w-[100svh]"
+          style={{ fontSize: "8svh", fontWeight: 700, lineHeight: 1.05 }}
         >
           Bridging Aachen&apos;s <span className="text-brand">Robotics</span> Scene.
         </h2>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-[5vh] items-stretch">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-[5svh] items-stretch">
           <div
             className="relative overflow-hidden bg-dark text-white"
             style={{
-              borderRadius: "3vh",
-              padding: "5vh",
-              minHeight: "55vh",
+              borderRadius: "3svh",
+              padding: "5svh",
+              minHeight: "55svh",
             }}
           >
             <div
@@ -58,11 +58,11 @@ export const AboutSection = () => {
             <div className="relative z-10 h-full flex flex-col justify-end">
               <p
                 style={{
-                  fontSize: "3vh",
+                  fontSize: "3svh",
                   fontWeight: 500,
                   lineHeight: 1.3,
                   color: "#fff",
-                  maxWidth: "40vh",
+                  maxWidth: "40svh",
                 }}
               >
                 Since 2023, uniting passionate minds to shape the{" "}
@@ -71,15 +71,15 @@ export const AboutSection = () => {
             </div>
           </div>
 
-          <div className="flex flex-col justify-start gap-[3vh]">
-            <p style={{ fontSize: "2.4vh", lineHeight: 1.5 }}>
+          <div className="flex flex-col justify-start gap-[3svh]">
+            <p style={{ fontSize: "2.4svh", lineHeight: 1.5 }}>
               Founded in 2023 as <strong>open robotic metaverse</strong>, we
               quickly spotted a critical gap: Aachen's vibrant robotics
               community was booming, yet efforts remained scattered: research
               institutes, startups, companies, and student teams often tackling
               the same challenges in parallel, reinventing the wheel.
             </p>
-            <p style={{ fontSize: "2.4vh", lineHeight: 1.5 }}>
+            <p style={{ fontSize: "2.4svh", lineHeight: 1.5 }}>
               Robotics Collective was reborn to bridge that gap by uniting
               academic groups, industry experts, and passionate individuals in
               an open, collaborative ecosystem.

--- a/rc-website/src/components/CookieConsentBanner.tsx
+++ b/rc-website/src/components/CookieConsentBanner.tsx
@@ -10,11 +10,11 @@ export const CookieConsentBanner: React.FC = () => {
   return (
     <div
       className="fixed bottom-0 left-0 right-0 z-[70] bg-dark text-white border-t border-white-10"
-      style={{ padding: "2vh 5vh" }}
+      style={{ padding: "2svh 5svh" }}
       role="dialog"
       aria-live="polite"
     >
-      <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 max-w-[150vh] mx-auto">
+      <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4 max-w-[150svh] mx-auto">
         <p className="text-small text-white/70 flex-1">
           We use cookies to analyze website traffic and improve your experience.
           See our{" "}

--- a/rc-website/src/components/FAQSection.tsx
+++ b/rc-website/src/components/FAQSection.tsx
@@ -58,13 +58,13 @@ export const FAQSection = ({ items = defaultItems }: { items?: FAQItem[] }) => {
     <section
       id="faq"
       className="relative bg-light text-dark"
-      style={{ padding: "12vh 5vh", minHeight: "100vh" }}
+      style={{ padding: "12svh 5svh", minHeight: "100svh" }}
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none select-none absolute top-0 right-[5vh]"
+        className="pointer-events-none select-none absolute top-0 right-[5svh]"
         style={{
-          fontSize: "40vh",
+          fontSize: "40svh",
           fontWeight: 500,
           lineHeight: 1,
           color: "#d8d8d8",
@@ -73,21 +73,21 @@ export const FAQSection = ({ items = defaultItems }: { items?: FAQItem[] }) => {
         04
       </div>
 
-      <div className="relative max-w-[120vh] mx-auto">
+      <div className="relative max-w-[120svh] mx-auto">
         <p
           className="uppercase mb-4"
           style={{
-            letterSpacing: "0.3vh",
+            letterSpacing: "0.3svh",
             color: "#666",
-            fontSize: "1.8vh",
+            fontSize: "1.8svh",
             fontWeight: 500,
           }}
         >
           04 · FAQ
         </p>
         <h2
-          className="mb-[6vh]"
-          style={{ fontSize: "8vh", fontWeight: 700, lineHeight: 1.05 }}
+          className="mb-[6svh]"
+          style={{ fontSize: "8svh", fontWeight: 700, lineHeight: 1.05 }}
         >
           Frequently Asked Questions.
         </h2>
@@ -102,9 +102,9 @@ export const FAQSection = ({ items = defaultItems }: { items?: FAQItem[] }) => {
               <AccordionTrigger
                 className="text-left hover:no-underline"
                 style={{
-                  fontSize: "2.7vh",
+                  fontSize: "2.7svh",
                   fontWeight: 500,
-                  padding: "3vh 0",
+                  padding: "3svh 0",
                   color: "#0d0d0d",
                 }}
               >
@@ -112,10 +112,10 @@ export const FAQSection = ({ items = defaultItems }: { items?: FAQItem[] }) => {
               </AccordionTrigger>
               <AccordionContent
                 style={{
-                  fontSize: "2vh",
+                  fontSize: "2svh",
                   lineHeight: 1.5,
                   color: "#333",
-                  paddingBottom: "3vh",
+                  paddingBottom: "3svh",
                 }}
               >
                 {typeof answer === "string" ? <p>{answer}</p> : answer}

--- a/rc-website/src/components/Footer.tsx
+++ b/rc-website/src/components/Footer.tsx
@@ -7,7 +7,7 @@ import { useConsent } from "@/contexts/ConsentContext";
 
 const XIcon = () => (
   <svg
-    style={{ width: "2.5vh", height: "2.5vh" }}
+    style={{ width: "2.5svh", height: "2.5svh" }}
     fill="currentColor"
     viewBox="0 0 50 50"
     aria-hidden="true"
@@ -18,7 +18,7 @@ const XIcon = () => (
 
 const LinkedInIcon = () => (
   <svg
-    style={{ width: "2.5vh", height: "2.5vh" }}
+    style={{ width: "2.5svh", height: "2.5svh" }}
     fill="currentColor"
     viewBox="0 0 50 50"
     aria-hidden="true"
@@ -33,21 +33,21 @@ export function Footer() {
   return (
     <footer
       className="bg-dark text-white overflow-hidden"
-      style={{ padding: "8vh 5vh 4vh" }}
+      style={{ padding: "8svh 5svh 4svh" }}
     >
-      <div className="max-w-[180vh] mx-auto">
-        <div className="flex flex-col lg:flex-row items-start lg:items-end justify-between gap-[4vh] mb-[6vh]">
+      <div className="max-w-[180svh] mx-auto">
+        <div className="flex flex-col lg:flex-row items-start lg:items-end justify-between gap-[4svh] mb-[6svh]">
           <Link href="/" className="flex items-center" aria-label="Robotics Collective Aachen home">
             <Image
               src="/logo.svg"
               alt="Robotics Collective Aachen"
               width={64}
               height={64}
-              style={{ height: "6vh", width: "auto", filter: "brightness(0) invert(1)" }}
+              style={{ height: "6svh", width: "auto", filter: "brightness(0) invert(1)" }}
             />
           </Link>
 
-          <nav className="flex flex-col lg:flex-row gap-[2vh] lg:gap-[3vh] text-left lg:text-right">
+          <nav className="flex flex-col lg:flex-row gap-[2svh] lg:gap-[3svh] text-left lg:text-right">
             <a href="#about" className="text-h5 hover:opacity-70 transition-opacity">
               About
             </a>
@@ -64,10 +64,10 @@ export function Footer() {
         </div>
 
         <div
-          className="border-t border-white-10 flex flex-col lg:flex-row justify-between items-start lg:items-center gap-[2vh]"
-          style={{ paddingTop: "3vh" }}
+          className="border-t border-white-10 flex flex-col lg:flex-row justify-between items-start lg:items-center gap-[2svh]"
+          style={{ paddingTop: "3svh" }}
         >
-          <div className="flex gap-[1.5vh]">
+          <div className="flex gap-[1.5svh]">
             <a
               href="https://x.com/robocollectiv"
               target="_blank"
@@ -84,7 +84,7 @@ export function Footer() {
               className="hover:opacity-70 transition-opacity"
               aria-label="Instagram"
             >
-              <Instagram style={{ width: "2.5vh", height: "2.5vh" }} />
+              <Instagram style={{ width: "2.5svh", height: "2.5svh" }} />
             </a>
             <a
               href="https://github.com/roboticscollective"
@@ -93,7 +93,7 @@ export function Footer() {
               className="hover:opacity-70 transition-opacity"
               aria-label="GitHub"
             >
-              <Github style={{ width: "2.5vh", height: "2.5vh" }} />
+              <Github style={{ width: "2.5svh", height: "2.5svh" }} />
             </a>
             <a
               href="https://www.linkedin.com/company/roboticscollective/"
@@ -110,7 +110,7 @@ export function Footer() {
             © {new Date().getFullYear()} Robotics Collective Aachen. All rights reserved.
           </p>
 
-          <div className="flex gap-[2vh] text-small" style={{ color: "#ffffff99" }}>
+          <div className="flex gap-[2svh] text-small" style={{ color: "#ffffff99" }}>
             <Link href="/privacy" className="hover:text-white transition-colors">
               Privacy
             </Link>

--- a/rc-website/src/components/HeroSection.tsx
+++ b/rc-website/src/components/HeroSection.tsx
@@ -8,10 +8,10 @@ export const HeroSection = () => {
       style={{
         minHeight: "100svh",
         padding:
-          "clamp(7rem, 16vh, 14rem) clamp(1.5rem, 7vh, 6rem) clamp(4rem, 8vh, 8rem)",
+          "clamp(7rem, 16svh, 14rem) clamp(1.5rem, 7svh, 6rem) clamp(4rem, 8svh, 8rem)",
         backgroundColor: "#0d0d0d",
-        borderBottomLeftRadius: "4vh",
-        borderBottomRightRadius: "4vh",
+        borderBottomLeftRadius: "4svh",
+        borderBottomRightRadius: "4svh",
       }}
     >
       {/* Looped video — centered card behind the hero content */}
@@ -19,9 +19,9 @@ export const HeroSection = () => {
         aria-hidden="true"
         className="hidden md:block pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
         style={{
-          width: "min(88%, 160vh)",
-          height: "min(80%, 80vh)",
-          borderRadius: "3vh",
+          width: "min(88%, 160svh)",
+          height: "min(80%, 80svh)",
+          borderRadius: "3svh",
           overflow: "hidden",
           boxShadow:
             "inset 0 0 0 1px #ffffff14, 0 0 80px -20px #47A8BD33",
@@ -59,14 +59,14 @@ export const HeroSection = () => {
         />
       </div>
 
-      <div className="relative z-10 w-full max-w-[140vh] pointer-events-none text-left">
+      <div className="relative z-10 w-full max-w-[140svh] pointer-events-none text-left">
         <h1
           className="text-white"
           style={{
-            fontSize: "clamp(3rem, min(9vh, 11vw), 6.5rem)",
+            fontSize: "clamp(3rem, min(9svh, 11vw), 6.5rem)",
             fontWeight: 800,
             lineHeight: 1.05,
-            marginBottom: "3vh",
+            marginBottom: "3svh",
           }}
         >
           Together, we shape the{" "}
@@ -74,11 +74,11 @@ export const HeroSection = () => {
         </h1>
         <p
           style={{
-            fontSize: "clamp(1.15rem, min(2.5vh, 4.4vw), 1.75rem)",
+            fontSize: "clamp(1.15rem, min(2.5svh, 4.4vw), 1.75rem)",
             fontWeight: 500,
             lineHeight: 1.4,
-            maxWidth: "70vh",
-            marginBottom: "4vh",
+            maxWidth: "70svh",
+            marginBottom: "4svh",
             color: "#ffffffcc",
           }}
         >
@@ -92,10 +92,10 @@ export const HeroSection = () => {
           rel="noopener noreferrer"
           className="btn-ghost pointer-events-auto"
           style={{
-            fontSize: "clamp(0.65rem, 1.5vh, 0.95rem)",
+            fontSize: "clamp(0.65rem, 1.5svh, 0.95rem)",
             fontWeight: 800,
             padding:
-              "clamp(0.5rem, 1.6vh, 1rem) clamp(1.1rem, 3.5vh, 2.25rem)",
+              "clamp(0.5rem, 1.6svh, 1rem) clamp(1.1rem, 3.5svh, 2.25rem)",
           }}
         >
           Apply Now

--- a/rc-website/src/components/Navbar.tsx
+++ b/rc-website/src/components/Navbar.tsx
@@ -59,22 +59,22 @@ export function Navbar() {
         className={`hidden lg:block fixed top-0 left-0 right-0 z-40 ${
           scrolled ? "" : ""
         }`}
-        style={{ padding: "2vh 5vh" }}
+        style={{ padding: "2svh 5svh" }}
       >
         <nav
           className={`transition-all duration-200 ${
             scrolled ? "bg-white/95 backdrop-blur-sm mx-auto" : "bg-transparent"
           }`}
           style={{
-            padding: scrolled ? "0.8vh 1.6vh" : "0",
-            borderRadius: scrolled ? "1.5vh" : "0",
+            padding: scrolled ? "0.8svh 1.6svh" : "0",
+            borderRadius: scrolled ? "1.5svh" : "0",
             boxShadow: scrolled ? "0 1px 2px rgba(0,0,0,0.06)" : "none",
             maxWidth: scrolled ? "fit-content" : "100%",
           }}
         >
           <div
             className="flex items-center justify-between"
-            style={{ gap: "3vh" }}
+            style={{ gap: "3svh" }}
           >
             <Link
               href="/"
@@ -86,15 +86,15 @@ export function Navbar() {
                 alt="Robotics Collective Aachen"
                 width={48}
                 height={48}
-                className="h-[4vh] w-auto transition-all duration-300"
+                className="h-[4svh] w-auto transition-all duration-300"
                 priority
               />
             </Link>
 
-            <div className="flex items-center" style={{ gap: "1.5vh" }}>
+            <div className="flex items-center" style={{ gap: "1.5svh" }}>
               {navLinks.map((link) => (
                 <a key={link.num} href={link.href} className={pillClass}>
-                  <span style={{ marginRight: "1.5vh", fontWeight: 500 }}>
+                  <span style={{ marginRight: "1.5svh", fontWeight: 500 }}>
                     {link.num}
                   </span>
                   {link.label}
@@ -105,7 +105,7 @@ export function Navbar() {
                 target="_blank"
                 rel="noopener noreferrer"
                 className={pillClass}
-                style={{ padding: "1vh 4vh" }}
+                style={{ padding: "1svh 4svh" }}
               >
                 Join us
               </a>
@@ -118,7 +118,7 @@ export function Navbar() {
       <div
         className="lg:hidden fixed top-0 left-0 right-0 z-40 flex justify-center pointer-events-none transition-all duration-300"
         style={{
-          padding: "1.8vh 1.5rem",
+          padding: "1.8svh 1.5rem",
           transform: mobileVisible ? "translateY(0)" : "translateY(-150%)",
           opacity: mobileVisible ? 1 : 0,
         }}
@@ -188,7 +188,7 @@ export function Navbar() {
       >
         <div
           className="flex flex-col h-full w-full"
-          style={{ padding: "1.8vh 1.5rem 3rem" }}
+          style={{ padding: "1.8svh 1.5rem 3rem" }}
         >
           <div className="flex items-center justify-between">
             <Link

--- a/rc-website/src/components/ProjectsSection.tsx
+++ b/rc-website/src/components/ProjectsSection.tsx
@@ -10,13 +10,13 @@ export const ProjectsSection = () => {
     <section
       id="projects"
       className="relative bg-light text-dark"
-      style={{ padding: "12vh 5vh", minHeight: "100vh" }}
+      style={{ padding: "12svh 5svh", minHeight: "100svh" }}
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none select-none absolute top-0 right-[5vh]"
+        className="pointer-events-none select-none absolute top-0 right-[5svh]"
         style={{
-          fontSize: "40vh",
+          fontSize: "40svh",
           fontWeight: 500,
           lineHeight: 1,
           color: "#d8d8d8",
@@ -25,32 +25,32 @@ export const ProjectsSection = () => {
         03
       </div>
 
-      <div className="relative max-w-[150vh] mx-auto">
+      <div className="relative max-w-[150svh] mx-auto">
         <p
           className="uppercase mb-4"
           style={{
-            letterSpacing: "0.3vh",
+            letterSpacing: "0.3svh",
             color: "#666",
-            fontSize: "1.8vh",
+            fontSize: "1.8svh",
             fontWeight: 500,
           }}
         >
           03 · Behind the Build
         </p>
         <h2
-          className="mb-[6vh] max-w-[100vh]"
-          style={{ fontSize: "8vh", fontWeight: 700, lineHeight: 1.05 }}
+          className="mb-[6svh] max-w-[100svh]"
+          style={{ fontSize: "8svh", fontWeight: 700, lineHeight: 1.05 }}
         >
           Behind the <span className="text-brand">Build</span>.
         </h2>
 
-        <div className="flex flex-col gap-[1vh]">
-          <div className="flex flex-col md:flex-row gap-[1vh] md:h-[40vh]">
+        <div className="flex flex-col gap-[1svh]">
+          <div className="flex flex-col md:flex-row gap-[1svh] md:h-[40svh]">
             {[projects[0], projects[1]].map((p) => (
               <ProjectCard key={p.id} image={p.image} />
             ))}
           </div>
-          <div className="flex flex-col md:flex-row gap-[1vh] md:h-[40vh]">
+          <div className="flex flex-col md:flex-row gap-[1svh] md:h-[40svh]">
             {[projects[2], projects[3]].map((p) => (
               <ProjectCard key={p.id} image={p.image} />
             ))}
@@ -66,7 +66,7 @@ function ProjectCard({ image }: { image: string }) {
     <div
       className="md:flex-1 overflow-hidden bg-dark aspect-video md:aspect-auto"
       style={{
-        borderRadius: "3vh",
+        borderRadius: "3svh",
         backgroundImage: `linear-gradient(#00000040, #00000040), url('${image}')`,
         backgroundSize: "cover",
         backgroundPosition: "center",

--- a/rc-website/src/components/TeamSection.tsx
+++ b/rc-website/src/components/TeamSection.tsx
@@ -7,22 +7,22 @@ export const TeamSection = () => {
       id="team"
       className="relative bg-dark text-white overflow-hidden"
       style={{
-        padding: "14vh 5vh",
-        minHeight: "100vh",
-        borderTopLeftRadius: "7vh",
-        borderTopRightRadius: "7vh",
-        borderBottomLeftRadius: "7vh",
-        borderBottomRightRadius: "7vh",
-        marginTop: "-7vh",
-        marginBottom: "-7vh",
+        padding: "14svh 5svh",
+        minHeight: "100svh",
+        borderTopLeftRadius: "7svh",
+        borderTopRightRadius: "7svh",
+        borderBottomLeftRadius: "7svh",
+        borderBottomRightRadius: "7svh",
+        marginTop: "-7svh",
+        marginBottom: "-7svh",
         zIndex: 2,
       }}
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none select-none absolute top-0 right-[5vh]"
+        className="pointer-events-none select-none absolute top-0 right-[5svh]"
         style={{
-          fontSize: "40vh",
+          fontSize: "40svh",
           fontWeight: 500,
           lineHeight: 1,
           color: "#ffffff14",
@@ -31,27 +31,27 @@ export const TeamSection = () => {
         05
       </div>
 
-      <div className="relative max-w-[150vh] mx-auto">
+      <div className="relative max-w-[150svh] mx-auto">
         <p
           className="uppercase mb-4"
           style={{
-            letterSpacing: "0.3vh",
+            letterSpacing: "0.3svh",
             color: "#ffffff99",
-            fontSize: "1.8vh",
+            fontSize: "1.8svh",
             fontWeight: 500,
           }}
         >
           05 · Team
         </p>
         <h2
-          className="mb-[3vh] max-w-[110vh]"
-          style={{ fontSize: "8vh", fontWeight: 700, lineHeight: 1.05 }}
+          className="mb-[3svh] max-w-[110svh]"
+          style={{ fontSize: "8svh", fontWeight: 700, lineHeight: 1.05 }}
         >
           The People Behind the <span className="text-brand">Collective</span>.
         </h2>
         <p
-          className="mb-[8vh] max-w-[100vh]"
-          style={{ fontSize: "2.5vh", color: "#ffffff99", lineHeight: 1.4 }}
+          className="mb-[8svh] max-w-[100svh]"
+          style={{ fontSize: "2.5svh", color: "#ffffff99", lineHeight: 1.4 }}
         >
           Our mission is to accelerate robotics adoption and the development of
           intelligent systems that interact harmoniously with humans and their
@@ -59,9 +59,9 @@ export const TeamSection = () => {
         </p>
 
         <h3
-          className="mb-[4vh]"
+          className="mb-[4svh]"
           style={{
-            fontSize: "3vh",
+            fontSize: "3svh",
             fontWeight: 700,
             color: "#fff",
           }}
@@ -69,9 +69,9 @@ export const TeamSection = () => {
           Leadership
         </h3>
         <div
-          className="grid gap-[4vh] mb-[12vh]"
+          className="grid gap-[4svh] mb-[12svh]"
           style={{
-            gridTemplateColumns: "repeat(auto-fit, minmax(24vh, 1fr))",
+            gridTemplateColumns: "repeat(auto-fit, minmax(24svh, 1fr))",
           }}
         >
           {leadership.map((m) => (
@@ -80,29 +80,29 @@ export const TeamSection = () => {
         </div>
 
         <h3
-          className="mb-[4vh]"
-          style={{ fontSize: "3vh", fontWeight: 700, color: "#fff" }}
+          className="mb-[4svh]"
+          style={{ fontSize: "3svh", fontWeight: 700, color: "#fff" }}
         >
           Partners
         </h3>
         <div
-          className="grid items-center gap-x-[6vh] gap-y-[4vh]"
+          className="grid items-center gap-x-[6svh] gap-y-[4svh]"
           style={{
-            gridTemplateColumns: "repeat(auto-fit, minmax(16vh, 1fr))",
+            gridTemplateColumns: "repeat(auto-fit, minmax(16svh, 1fr))",
           }}
         >
           {partners.map((p) => (
             <div
               key={p.name}
               className="flex items-center justify-center"
-              style={{ height: "8vh" }}
+              style={{ height: "8svh" }}
             >
               {p.wordmark ? (
                 <span
                   className="group inline-flex items-baseline gap-[0.05em] font-medium leading-none text-white"
                   style={{
                     fontFamily: "'Afacad', 'Inter', ui-sans-serif, sans-serif",
-                    fontSize: "3.4vh",
+                    fontSize: "3.4svh",
                     letterSpacing: "-0.035em",
                   }}
                 >
@@ -140,23 +140,23 @@ function MemberCard({ member }: { member: TeamMember }) {
       <div
         className="relative overflow-hidden bg-white-10"
         style={{
-          width: "18vh",
-          height: "18vh",
+          width: "18svh",
+          height: "18svh",
           borderRadius: "50%",
-          marginBottom: "2vh",
+          marginBottom: "2svh",
         }}
       >
         <Image
           src={member.image}
           alt={member.name}
           fill
-          sizes="20vh"
+          sizes="20svh"
           className="object-cover"
         />
       </div>
-      <div style={{ fontSize: "2.4vh", fontWeight: 700 }}>{member.name}</div>
+      <div style={{ fontSize: "2.4svh", fontWeight: 700 }}>{member.name}</div>
       <div
-        style={{ fontSize: "1.7vh", color: "#ffffff99", marginTop: "0.4vh" }}
+        style={{ fontSize: "1.7svh", color: "#ffffff99", marginTop: "0.4svh" }}
       >
         {member.role}
       </div>

--- a/rc-website/src/components/VisionSection.tsx
+++ b/rc-website/src/components/VisionSection.tsx
@@ -74,22 +74,22 @@ export const VisionSection = () => {
       id="network"
       className="relative bg-dark text-white overflow-hidden"
       style={{
-        padding: "14vh 5vh",
-        minHeight: "100vh",
-        borderTopLeftRadius: "7vh",
-        borderTopRightRadius: "7vh",
-        borderBottomLeftRadius: "7vh",
-        borderBottomRightRadius: "7vh",
-        marginTop: "-7vh",
-        marginBottom: "-7vh",
+        padding: "14svh 5svh",
+        minHeight: "100svh",
+        borderTopLeftRadius: "7svh",
+        borderTopRightRadius: "7svh",
+        borderBottomLeftRadius: "7svh",
+        borderBottomRightRadius: "7svh",
+        marginTop: "-7svh",
+        marginBottom: "-7svh",
         zIndex: 2,
       }}
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none select-none absolute top-0 right-[5vh]"
+        className="pointer-events-none select-none absolute top-0 right-[5svh]"
         style={{
-          fontSize: "40vh",
+          fontSize: "40svh",
           fontWeight: 500,
           lineHeight: 1,
           color: "#ffffff14",
@@ -98,13 +98,13 @@ export const VisionSection = () => {
         02
       </div>
 
-      <div className="relative max-w-[170vh] mx-auto">
+      <div className="relative max-w-[170svh] mx-auto">
         <p
           className="uppercase mb-4"
           style={{
-            letterSpacing: "0.3vh",
+            letterSpacing: "0.3svh",
             color: "#ffffff99",
-            fontSize: "1.8vh",
+            fontSize: "1.8svh",
             fontWeight: 500,
           }}
         >
@@ -112,14 +112,14 @@ export const VisionSection = () => {
         </p>
 
         <h2
-          className="mb-[3vh] max-w-[120vh]"
-          style={{ fontSize: "8vh", fontWeight: 700, lineHeight: 1.05 }}
+          className="mb-[3svh] max-w-[120svh]"
+          style={{ fontSize: "8svh", fontWeight: 700, lineHeight: 1.05 }}
         >
           Building Europe&apos;s Robotics <span className="text-brand">Network</span>.
         </h2>
         <p
-          className="mb-[8vh] max-w-[110vh]"
-          style={{ fontSize: "2.5vh", color: "#ffffff99", lineHeight: 1.5 }}
+          className="mb-[8svh] max-w-[110svh]"
+          style={{ fontSize: "2.5svh", color: "#ffffff99", lineHeight: 1.5 }}
         >
           Robotics Collective Aachen is a founding member of{" "}
           <strong className="text-brand">ESRA</strong>, the European Student
@@ -130,16 +130,16 @@ export const VisionSection = () => {
           funding access.
         </p>
 
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-[5vh] items-center">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-[5svh] items-center">
           {isDesktop && <NetworkMap markers={markers} />}
 
-          <div className="lg:col-span-3 flex flex-col gap-[2.5vh]">
+          <div className="lg:col-span-3 flex flex-col gap-[2.5svh]">
             <h3
               style={{
-                fontSize: "2.2vh",
+                fontSize: "2.2svh",
                 fontWeight: 700,
                 color: "#fff",
-                letterSpacing: "0.1vh",
+                letterSpacing: "0.1svh",
               }}
             >
               Founding Members
@@ -172,22 +172,22 @@ export const VisionSection = () => {
                     }}
                     className="flex items-center justify-between"
                     style={{
-                      padding: "1.1vh 0",
+                      padding: "1.1svh 0",
                       borderBottom: "1px solid #ffffff1f",
                       color: isHome ? "#ffffff" : "#ffffffb3",
-                      fontSize: "1.7vh",
+                      fontSize: "1.7svh",
                       fontWeight: isHome ? 700 : 500,
-                      letterSpacing: "0.02vh",
+                      letterSpacing: "0.02svh",
                     }}
                   >
-                    <span className="flex items-center" style={{ gap: "1.4vh" }}>
+                    <span className="flex items-center" style={{ gap: "1.4svh" }}>
                       <span
                         style={{
-                          fontSize: "1.2vh",
+                          fontSize: "1.2svh",
                           fontWeight: 500,
                           color: isHome ? "#ffffff" : "#ffffff55",
                           fontVariantNumeric: "tabular-nums",
-                          minWidth: "2.4vh",
+                          minWidth: "2.4svh",
                         }}
                       >
                         {String(i + 1).padStart(2, "0")}
@@ -197,10 +197,10 @@ export const VisionSection = () => {
                         {org.city && (
                           <span
                             style={{
-                              fontSize: "1.1vh",
+                              fontSize: "1.1svh",
                               fontWeight: 500,
                               color: "#ffffff66",
-                              letterSpacing: "0.05vh",
+                              letterSpacing: "0.05svh",
                               textTransform: "uppercase",
                             }}
                           >
@@ -213,11 +213,11 @@ export const VisionSection = () => {
                       <span
                         aria-label="Your organization"
                         style={{
-                          width: "0.9vh",
-                          height: "0.9vh",
+                          width: "0.9svh",
+                          height: "0.9svh",
                           borderRadius: "50%",
                           backgroundColor: "#22c55e",
-                          boxShadow: "0 0 0 0.4vh #22c55e33",
+                          boxShadow: "0 0 0 0.4svh #22c55e33",
                         }}
                       />
                     )}
@@ -230,7 +230,7 @@ export const VisionSection = () => {
               href="https://www.linkedin.com/feed/update/urn:li:activity:7385056010165448704"
               target="_blank"
               rel="noopener noreferrer"
-              className="btn-outline-pill mt-[1vh] w-fit"
+              className="btn-outline-pill mt-[1svh] w-fit"
             >
               Read the launch announcement
             </a>

--- a/rc-website/tailwind.config.ts
+++ b/rc-website/tailwind.config.ts
@@ -71,17 +71,17 @@ const config: Config = {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
-        "vh-sm": "1vh",
-        "vh-md": "3vh",
-        "vh-lg": "4vh",
-        "vh-pill": "5vh",
+        "vh-sm": "1svh",
+        "vh-md": "3svh",
+        "vh-lg": "4svh",
+        "vh-pill": "5svh",
       },
       fontFamily: {
         satoshi: ["var(--font-satoshi)", ...fontFamily.sans],
         sans: ["var(--font-satoshi)", ...fontFamily.sans],
       },
       letterSpacing: {
-        btn: "0.5vh",
+        btn: "0.5svh",
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
Convert all numeric vh units to svh across the type scale, layout, and spacing. In in-app browsers (Instagram, Facebook), the toolbar animates in/out when scrolling stops, changing the vh reference and reflowing the whole vh-based design. svh is a stable unit and does not recompute on toolbar transitions, matching the hero's existing 100svh.